### PR TITLE
Plugins filter

### DIFF
--- a/pyblish/__init__.py
+++ b/pyblish/__init__.py
@@ -17,6 +17,7 @@ _registered_test = dict()
 _registered_hosts = list()
 _registered_targets = list()
 _registered_gui = list()
+_registered_plugin_filters = list()
 
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "_registered_hosts",
     "_registered_targets",
     "_registered_gui",
+    "_registered_plugin_filters"
 ]

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -80,6 +80,11 @@ from .plugin import (
     deregister_all_callbacks,
     registered_callbacks,
 
+    register_discovery_filter,
+    deregister_discovery_filter,
+    deregister_all_discovery_filters,
+    registered_discovery_filters,
+
     sort as sort_plugins,
 
     registered_paths,

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1229,7 +1229,7 @@ def deregister_discovery_filter(callback):
 def deregister_all_discovery_filters():
     """Deregisters all plugin filters"""
 
-    _registered_plugin_filters.clear()
+    del _registered_plugin_filters[:]
 
 
 def registered_discovery_filters():

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -38,7 +38,6 @@ from . import lib
 from .vendor import iscompatible, six
 
 log = logging.getLogger("pyblish.plugin")
-from pprint import pprint
 
 __metaclass__ = type  # Make all classes new-style
 
@@ -1238,34 +1237,25 @@ def registered_discovery_filters():
     return _registered_plugin_filters
 
 
-def filter_plugin(plugin):
+def filter_plugins(plugins):
     """Trigger registered plugin filters
 
     Keyword arguments are passed from caller to callee.
 
     Arguments:
-        plugin (Object): plugin to be filtered
-
-    Returns:
-        tuple with plugin instance and bool if plugin should be filtered or
-        not.
+        plugins (Dict): dictionary of plugins to be filtered
 
     """
 
     if not _registered_plugin_filters:
-        return plugin, False
-
-    print(_registered_plugin_filters)
+        return
 
     filtered = False
     for callback in _registered_plugin_filters:
         try:
-            plugin, filtered = callback(plugin)
+            plugin, filtered = callback(plugins)
         except Exception:
             log.error("Plugin filter failed.", exc_info=True)
-            filtered = True
-
-        return plugin, filtered
 
 
 def environment_paths():
@@ -1400,13 +1390,8 @@ def discover(type=None, regex=None, paths=None):
 
         plugins[plugin.__name__] = plugin
 
-    filtered_plugins = {}
-    for name, plugin in plugins.items():
-        modified, filtered = filter_plugin(plugin)
-        if not filtered:
-            filtered_plugins[name] = modified
-
-    plugins = list(filtered_plugins.values())
+    filter_plugins(plugins)
+    plugins = list(plugins.values())
     sort(plugins)  # In-place
 
     return plugins

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -32,6 +32,7 @@ def setup_empty():
     pyblish.plugin.deregister_all_hosts()
     pyblish.plugin.deregister_all_callbacks()
     pyblish.plugin.deregister_all_targets()
+    pyblish.api.deregister_all_discovery_filters()
 
 
 def teardown():
@@ -44,6 +45,7 @@ def teardown():
     os.environ["PYBLISHPLUGINPATH"] = ENVIRONMENT
     pyblish.api.deregister_all_plugins()
     pyblish.api.deregister_all_hosts()
+    pyblish.api.deregister_all_discovery_filters()
     pyblish.api.deregister_test()
     pyblish.api.__init__()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -955,3 +955,55 @@ def test_validate_publish_data_member_type():
     # NOTE: This assumes the test succeeds. If it fails, then
     # subsequent tests can fail because of it.
     pyblish.plugin.STRICT_DATATYPES = False
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_discovery_filter():
+    """Plugins can be filtered and modified"""
+
+    class MyFilteredPlugin(pyblish.plugin.Collector):
+        pass
+
+    class MyModifiedPlugin(pyblish.plugin.Validator):
+        optional = False
+        pass
+
+    def my_plugin_filter(plugin):
+        if plugin.__name__ == "MyFilteredPlugin":
+            return plugin, True
+
+        if plugin.__name__ == "MyModifiedPlugin":
+            plugin.optional = True
+            return plugin, False
+
+        return plugin, False
+
+    pyblish.api.register_plugin(MyFilteredPlugin)
+    pyblish.api.register_plugin(MyModifiedPlugin)
+    pyblish.api.register_discovery_filter(my_plugin_filter)
+    plugins = pyblish.api.discover()
+    assert len(plugins) == 1, plugins
+    assert plugins[0].__name__ == MyModifiedPlugin.__name__
+    assert plugins[0].optional is True
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_deregister_discovery():
+    """Test discovery filters can be deregistered"""
+    class MyFilteredPlugin(pyblish.plugin.Collector):
+        pass
+
+    def my_plugin_filter(plugin):
+        if plugin.__name__ == "MyFilteredPlugin":
+            return plugin, True
+
+        return plugin, False
+
+    pyblish.api.register_plugin(MyFilteredPlugin)
+    pyblish.api.register_discovery_filter(my_plugin_filter)
+    plugins = pyblish.api.discover()
+    assert len(plugins) == 0, plugins
+    pyblish.api.register_plugin(MyFilteredPlugin)
+    pyblish.api.deregister_discovery_filter(my_plugin_filter)
+    plugins = pyblish.api.discover()
+    assert len(plugins) == 1, plugins

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -968,15 +968,14 @@ def test_discovery_filter():
         optional = False
         pass
 
-    def my_plugin_filter(plugin):
-        if plugin.__name__ == "MyFilteredPlugin":
-            return plugin, True
+    def my_plugin_filter(plugins):
+        for name, plugin in list(plugins.items()):
+            if plugin.__name__ == "MyFilteredPlugin":
+                del plugins[name]
 
-        if plugin.__name__ == "MyModifiedPlugin":
-            plugin.optional = True
-            return plugin, False
-
-        return plugin, False
+            if plugin.__name__ == "MyModifiedPlugin":
+                plugin.optional = True
+        pass
 
     pyblish.api.register_plugin(MyFilteredPlugin)
     pyblish.api.register_plugin(MyModifiedPlugin)
@@ -993,11 +992,12 @@ def test_deregister_discovery():
     class MyFilteredPlugin(pyblish.plugin.Collector):
         pass
 
-    def my_plugin_filter(plugin):
-        if plugin.__name__ == "MyFilteredPlugin":
-            return plugin, True
+    def my_plugin_filter(plugins):
+        for name, plugin in list(plugins.items()):
+            if plugin.__name__ == "MyFilteredPlugin":
+                del plugins[name]
 
-        return plugin, False
+        pass
 
     pyblish.api.register_plugin(MyFilteredPlugin)
     pyblish.api.register_discovery_filter(my_plugin_filter)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -966,16 +966,17 @@ def test_discovery_filter():
 
     class MyModifiedPlugin(pyblish.plugin.Validator):
         optional = False
-        pass
 
     def my_plugin_filter(plugins):
-        for name, plugin in list(plugins.items()):
-            if plugin.__name__ == "MyFilteredPlugin":
-                del plugins[name]
+        for plugin in list(plugins):
 
+            # Plug-ins can be removed..
+            if plugin.__name__ == "MyFilteredPlugin":
+                plugins.remove(plugin)
+
+            # ..and modified
             if plugin.__name__ == "MyModifiedPlugin":
                 plugin.optional = True
-        pass
 
     pyblish.api.register_plugin(MyFilteredPlugin)
     pyblish.api.register_plugin(MyModifiedPlugin)
@@ -993,11 +994,9 @@ def test_deregister_discovery():
         pass
 
     def my_plugin_filter(plugins):
-        for name, plugin in list(plugins.items()):
+        for plugin in list(plugins):
             if plugin.__name__ == "MyFilteredPlugin":
-                del plugins[name]
-
-        pass
+                plugins.remove(plugin)
 
     pyblish.api.register_plugin(MyFilteredPlugin)
     pyblish.api.register_discovery_filter(my_plugin_filter)


### PR DESCRIPTION
### This implements pyblish/pyblish-base#343

Adding ability to filter plugins and modify plugins during discovery. This is using same `register_*` logic as already existing api. 

### Adding filter function:

```python
pyblish.api.register_discovery_filter(my_filter)
```
Filter function must return tuple `(plugin, filtered)` -> `(class, bool)`
**Plugin** is plugin class processed by filter function, **filtered** is bool indicating wheter plugin should be filtered out or not.

So simple filter function can look like:
```python
def my_filter_function(plugin):
    if plugin.__name__ == 'FilteredPlugin':
        return plugin, True
   return plugin, False
```
This can also modify plugin:
```python
def my_filter_function(plugin):
    if plugin.__name__ == 'ModifiedPlugin':
        plugin.optional = False
   return plugin, False
```

### This PR adds:
```
register_discovery_filter,
deregister_discovery_filter,
deregister_all_discovery_filters,
registered_discovery_filters
```
